### PR TITLE
Resolvers can be a single function

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,14 +1,14 @@
 import postcss, { Result, Root, Container } from 'postcss';
 import createRuleExtractor from './rule-extractor'; // tslint:disable-line:import-name
 import RecursiveProcessor from './RecursiveProcessor';
-import { Resolver, NodeResolver, NodeResolverOptions, ResolverChain } from './resolvers';
+import { Resolver, ResolverOption, NodeResolver, NodeResolverOptions, ResolverChain } from './resolvers';
 
 /**
  * Options for initializing this plugin.
  */
 export interface ImporterOptions {
   /** An ordered list of resolvers to use to find the imported style sheet. Defaults to a single NodeResolver. */
-  resolvers?: Resolver[];
+  resolvers?: ResolverOption[];
 }
 
 /**
@@ -23,7 +23,7 @@ export interface ImporterOptions {
  */
 export default postcss.plugin<ImporterOptions>('postcss-importer', ({ resolvers = [] }: ImporterOptions = {}) => {
   // Build the resolver, and potentially the resolver chain
-  const resolver: Resolver = (() => {
+  const resolver: ResolverOption = (() => {
     if (resolvers.length === 0) {
       return new NodeResolver();
     }
@@ -50,4 +50,4 @@ export default postcss.plugin<ImporterOptions>('postcss-importer', ({ resolvers 
 });
 
 // Re-exporting interfaces/values that are meant to be public
-export { Resolver, NodeResolver, NodeResolverOptions, ResolverChain };
+export { Resolver, ResolverOption, NodeResolver, NodeResolverOptions, ResolverChain };

--- a/src/resolvers/index.ts
+++ b/src/resolvers/index.ts
@@ -13,12 +13,18 @@ export interface ResolverResult {
   file?: string;
 }
 
+export type ResolverOption = Resolver | ResolverFn;
+
+export interface ResolverFn {
+  (importParams: ImportParams, result: Result): Promise<ResolverResult>;
+}
+
 /**
  * Resolvers are responsible for turning `ImportParams` into CSS string content. See `NodeResolver` for an example.
  */
 export interface Resolver {
   /** Returns a Promise for CSS string content (and optionally a file) for the given `ImportParams` */
-  resolve: (importParams: ImportParams, result: Result) => Promise<ResolverResult>;
+  resolve: ResolverFn;
   /** Returns false when the resolver can synchronously determine that it cannot resolve the given `ImportParams` */
   willResolve?: (importParams: ImportParams, result: Result) => boolean;
 }

--- a/test/integration/plugin.test.ts
+++ b/test/integration/plugin.test.ts
@@ -125,3 +125,22 @@ describe('plugin with default options', () => {
     });
   });
 });
+
+describe('plugin with resolver option', () => {
+  it('should use a function as the resolver option', (done) => {
+    const expectedContent = '.resolved { foo: bar; }';
+    const inputCss = "@import 'foo';";
+    const dummyFilename = __filename;
+
+    // TODO: verify that the file property of the ResolverResult works
+    postcss([importer({
+      resolvers: [async () => { return { content: expectedContent }; }],
+    })])
+      .process(inputCss, { from: dummyFilename, to: dummyFilename })
+      .then((result) => {
+        assert.include(result.css, expectedContent);
+        done();
+      })
+      .catch(done);
+  });
+});


### PR DESCRIPTION
fixes #5 

Changes the options from accepting a `Resolver` to a `ResolverOption`. `ResolverOption` is defined as either a `Resolver` or a `ResolverFn`. The `ResolverFn` type is the same as the type for the `Resolver[resolve]` function. Effectively, this means that users can simply specify a function as an entire resolver.

The `ResolverChain` and `RecursiveProcessor` implementations had to be updated to work with either a `ResolverFn` or a `Resolver`. This could be further simplified if we simply wrapped `ResolverFn`s in a `Resolver` before the rest of the code interacted with it, so that they never know the difference. Opted not to do this right now because the complexity of supporting this in two places is pretty low, and creating more objects seems like a memory use that isn't really necessary.